### PR TITLE
Strict Datetime Format

### DIFF
--- a/cashflows/util/time.py
+++ b/cashflows/util/time.py
@@ -1,12 +1,13 @@
 import warnings
 
 from datetime import datetime
-from dateutil.parser import parse
 
 from cashflows.settings import TIME_TYPES
 
 
 class Time(object):
+
+    DATETIME_FORMAT = "%Y-%m-%d"
 
     def __init__(self, value, time_type="date"):
         self.time_type = self.validate_time_type(time_type)
@@ -46,7 +47,7 @@ class Time(object):
             return value
         if time_type == "date":
             if isinstance(value, str):
-                value = parse(value)
+                value = datetime.strptime(value, Time.DATETIME_FORMAT)
             if isinstance(value, datetime):
                 return value
         raise ValueError("Value parameter is not a valid type.")


### PR DESCRIPTION
#### What does this PR do?
Change the time parser from a general format to a specific one (i.e. %Y-%m-%d).
This avoids parsing mistakes from string to datetime objects.  

#### Where should the reviewer start?
Just a small modification at the Time object file.

#### How should this be manually tested?
Run the standard tests: `python setup.py tests`
#### Any background context you want to provide?
The principal parse error involved unregular parsing of the format %d-%m-%Y when d < 12.
